### PR TITLE
Better Separation of Platform and Stack

### DIFF
--- a/roles/upstream/tasks/main.yml
+++ b/roles/upstream/tasks/main.yml
@@ -9,14 +9,6 @@
 - name: Gather Installed Services
   service_facts:
 
-- name: Get rid of Network Manager
-  service: name=NetworkManager state=stopped enabled=no
-  when: "'NetworkManager.service' in services"
-
-- name: Disable firewall
-  service: name=firewalld state=stopped enabled=no
-  when: "'firewalld.service' in services"
-
 - name: Set hostname
   command: "hostnamectl set-hostname {{ inventory_hostname_short }}.pri.{{ cluster_name }}.cluster.local"
 

--- a/roles/upstream/tasks/main.yml
+++ b/roles/upstream/tasks/main.yml
@@ -9,9 +9,6 @@
 - name: Gather Installed Services
   service_facts:
 
-- name: Set hostname
-  command: "hostnamectl set-hostname {{ inventory_hostname_short }}.pri.{{ cluster_name }}.cluster.local"
-
 - name: Install EPEL Repo
   yum: name=epel-release state=present
 

--- a/roles/upstream/tasks/main.yml
+++ b/roles/upstream/tasks/main.yml
@@ -20,14 +20,6 @@
 - name: Set hostname
   command: "hostnamectl set-hostname {{ inventory_hostname_short }}.pri.{{ cluster_name }}.cluster.local"
 
-- name: Ensure search domain exists in resolv.conf
-  lineinfile:
-    path: /etc/resolv.conf
-    regexp: "^search (.*?)( pri.{{ cluster_name }}.cluster.local|$)"
-    line: 'search \1 pri.{{ cluster_name }}.cluster.local'
-    backrefs: true
-    state: present
-
 - name: Install EPEL Repo
   yum: name=epel-release state=present
 


### PR DESCRIPTION
It has been recognised that the waters between platform and stack had become muddied, this PR (and openflighthpc/openflight-compute-cluster-builder#7 ) addresses this by removing non-stack, platform-specific commands from the playbook:

- Remove setting of search domain in `resolv.conf`
- No longer disable/stop firewalld and NetworkManager
- No longer set hostname

Fixes #6 