### PR TITLE
CentOS 8 Support

### DIFF
--- a/roles/flightenv/tasks/main.yml
+++ b/roles/flightenv/tasks/main.yml
@@ -1,16 +1,17 @@
 - name: Install packages
   yum:
     name:
+      "{{ all_packages }}"
+    state: present
+    disable_gpg_check: yes
+  vars:
+    generic_list:
       - flight-runway
       - flight-starter
       - flight-env
       - flight-desktop
-      - vte
       - vte-profile
-      - pdsh
-      - pdsh-mod-genders
-    state: present
-    disable_gpg_check: yes
+    all_packages: "{{ generic_list + ['vte', 'pdsh', 'pdsh-mod-genders'] if ansible_distribution_major_version == '7' else generic_list }}"
 
 - name: Set cluster name
   command: "/opt/flight/bin/flight config set cluster.name {{ cluster_name }}"

--- a/roles/nfs/tasks/main.yml
+++ b/roles/nfs/tasks/main.yml
@@ -48,9 +48,8 @@
   when: nfs_role == 'server' and ansible_distribution_major_version == '8'
 
 - name: Start NFS service
-  service: "name={{ service_name }} state=started enabled=yes"
-  vars:
-    service_name: "{{ 'nfs-client' if ansible_distribution_major_version == '8' else 'nfs'}}"
+  service: "name=nfs state=started enabled=yes"
+  when: ansible_distribution_major_version == '7'
 
 - name: Export mounts
   when: nfs_role == 'server'

--- a/roles/nfs/tasks/main.yml
+++ b/roles/nfs/tasks/main.yml
@@ -12,9 +12,9 @@
 - name: Increase NFS thread count
   when: nfs_role == "server"
   replace:
-    path: /etc/sysconfig/nfs
-    regexp: '^#\RPCNFSDCOUNT.*$'
-    replace: 'RPCNFSDCOUNT=32'
+    path: /etc/nfs.conf
+    regexp: '^# threads=8.*$'
+    replace: 'thread=32'
 
 - name: Create export file
   when: nfs_role == "server"

--- a/roles/nfs/tasks/main.yml
+++ b/roles/nfs/tasks/main.yml
@@ -43,8 +43,14 @@
     mode: 0775
   with_dict: "{{ nfs_shares }}"
 
+- name: Start NFS server service
+  service: "name=nfs-server state=started enabled=yes"
+  when: nfs_role == 'server' and ansible_distribution_major_version == '8'
+
 - name: Start NFS service
-  service: name=nfs state=started enabled=yes
+  service: "name={{ service_name }} state=started enabled=yes"
+  vars:
+    service_name: "{{ 'nfs-client' if ansible_distribution_major_version == '8' else 'nfs'}}"
 
 - name: Export mounts
   when: nfs_role == 'server'

--- a/roles/slurm/tasks/main.yml
+++ b/roles/slurm/tasks/main.yml
@@ -23,14 +23,16 @@
 - name: Install SLURM controller packages
   yum:
     name: 
-      - mariadb
-      - mariadb-test
-      - mariadb-libs
-      - mariadb-embedded
-      - mariadb-bench
-      - flight-slurm-slurmctld
+      "{{ all_packages }}"
     state: present
     disable_gpg_check: yes
+  vars:
+    generic_list:
+      - mariadb
+      - mariadb-test
+      - mariadb-embedded
+      - flight-slurm-slurmctld
+    all_packages: "{{ generic_list + ['mariadb-libs', 'mariadb-bench'] if ansible_distribution_major_version == '7' else generic_list }}"
   when: slurm_role == 'controller'
 
 - name: Turn on MariaDB

--- a/roles/upstream/tasks/main.yml
+++ b/roles/upstream/tasks/main.yml
@@ -33,14 +33,21 @@
 
 - name: Add OpenFlight Release Repo
   yum: 
-    name: "https://repo.openflighthpc.org/openflight/{{ ansible_distribution |lower }}/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/openflighthpc-release-2-1.noarch.rpm"
+    name: "https://repo.openflighthpc.org/openflight/{{ ansible_distribution |lower }}/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/openflighthpc-release-3-1.noarch.rpm"
     state: present
 
 - name: Enabling OpenFlight Development Repo
   ini_file:
-    dest: /etc/yum.repos.d/openflight-dev.repo
+    dest: /etc/yum.repos.d/openflight.repo
     section: openflight-dev
     option: enabled
     value: 1
   when: flightenv_dev
 
+- name: Enable PowerTools repository
+  ini_file:
+    dest: /etc/yum.repos.d/CentOS-PowerTools.repo
+    section: PowerTools
+    option: enabled
+    value: 1
+  when: ansible_distribution == "CentOS" and ansible_distribution_major_version == '8'

--- a/roles/upstream/tasks/main.yml
+++ b/roles/upstream/tasks/main.yml
@@ -14,14 +14,21 @@
 
 - name: Add OpenFlight Release Repo
   yum: 
-    name: "https://repo.openflighthpc.org/openflight/{{ ansible_distribution |lower }}/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/openflighthpc-release-2-1.noarch.rpm"
+    name: "https://repo.openflighthpc.org/openflight/{{ ansible_distribution |lower }}/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/openflighthpc-release-3-1.noarch.rpm"
     state: present
 
 - name: Enabling OpenFlight Development Repo
   ini_file:
-    dest: /etc/yum.repos.d/openflight-dev.repo
+    dest: /etc/yum.repos.d/openflight.repo
     section: openflight-dev
     option: enabled
     value: 1
   when: flightenv_dev
 
+- name: Enable PowerTools repository
+  ini_file:
+    dest: /etc/yum.repos.d/CentOS-PowerTools.repo
+    section: PowerTools
+    option: enabled
+    value: 1
+  when: ansible_distribution == "CentOS" and ansible_distribution_major_version == '8'


### PR DESCRIPTION
This PR adds CentOS 8 support to the playbook, namely:
- Handles package naming/availability differences between releases
- Updates the NFS thread counting to use the new method (that's supported in both releases)
- Service management for different NFS service naming in releases
- Enables PowerTools repo for CentOS 8

Additionally, the release RPM has been updating to contain all repos in one file instead of a file per repo.