### PR TITLE
Change Hostnames

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -1,7 +1,7 @@
 # Global
 cluster_name: mycluster # Used by SLURM and Flight Env
-gateway_node: gateway1 #Used by SLURM and Flight Env (genders)
-compute_nodes: node[01-08]
+gateway_node: chead1 #Used by SLURM and Flight Env (genders)
+compute_nodes: cnode[01-08]
 
 # FlightEnv Settings
 
@@ -21,27 +21,27 @@ munge_key: ReplaceThisWithMungeKeyRandomisedStringOrSomethingElseReallySecure
 nfs_role: client # Default to NFS client, override in subgroups
 nfs_shares:
   /export/apps:
-    server: gateway1
+    server: chead1
     mountpoint: /opt/apps
     export_opts: 10.10.0.0/255.255.0.0(rw,no_root_squash,sync)
     mount_opts: intr,rsize=32768,wsize=32768,vers=3,_netdev,nofail
   /export/data:
-    server: gateway1
+    server: chead1
     mountpoint: /data
     export_opts: 10.10.0.0/255.255.0.0(rw,no_root_squash,sync)
     mount_opts: intr,rsize=32768,wsize=32768,vers=3,_netdev,nofail
   /export/service:
-    server: gateway1
+    server: chead1
     mountpoint: /opt/service
     export_opts: 10.10.0.0/255.255.0.0(rw,no_root_squash,sync)
     mount_opts: intr,rsize=32768,wsize=32768,vers=3,_netdev,nofail
   /export/site:
-    server: gateway1
+    server: chead1
     mountpoint: /opt/site
     export_opts: 10.10.0.0/255.255.0.0(rw,no_root_squash,sync)
     mount_opts: intr,rsize=32768,wsize=32768,vers=3,_netdev,nofail
   /home:
-    server: gateway1
+    server: chead1
     mountpoint: /home
     export_opts: 10.10.0.0/255.255.0.0(rw,no_root_squash,sync)
     mount_opts: intr,rsize=32768,wsize=32768,vers=3,_netdev,nofail


### PR DESCRIPTION
Rename to use chead & cnode instead of gateway & node naming conventions (thanks for this Dan).

Aligns with changes in openflighthpc/openflight-compute-cluster-builder/pull/10